### PR TITLE
Bugfix/serde dhall upgrade

### DIFF
--- a/config-derive/Cargo.toml
+++ b/config-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config-derive"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "twelf"
 version = "0.1.7"
-authors = ["Benkamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
+authors = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"
 keywords = ["config", "configuration", "env", "environment", "settings"]

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -23,3 +23,4 @@ serde_yaml = { version = "0.8.14" }
 serde_dhall = { version = "0.10.0" }
 toml_rs = { version =  "0.5.7", package = "toml" }
 clap_rs = { version = "2.33.3", package = "clap" }
+

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "twelf"
-version = "0.1.6"
-authors = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
+version = "0.1.7"
+authors = ["Benkamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"
 keywords = ["config", "configuration", "env", "environment", "settings"]

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -23,4 +23,3 @@ serde_yaml = { version = "0.8.14" }
 serde_dhall = { version = "0.10.0" }
 toml_rs = { version =  "0.5.7", package = "toml" }
 clap_rs = { version = "2.33.3", package = "clap" }
-

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -20,6 +20,6 @@ log = "0.4.11"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_ini = { version = "0.2.0" }
 serde_yaml = { version = "0.8.14" }
-serde_dhall = { version = "0.9.0" }
+serde_dhall = { version = "0.10.0" }
 toml_rs = { version =  "0.5.7", package = "toml" }
 clap_rs = { version = "2.33.3", package = "clap" }


### PR DESCRIPTION
I received the following compiler error with the latest stable Rust that was fixed by upgrading `serde_dhall` to `0.10.0`:
```
error[E0283]: type annotations needed
   --> /home/tnewman/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_dhall-0.9.0/src/deserialize.rs:142:42
    |
142 |                 m.iter().map(|(k, v)| (k.as_ref(), val(v))),
    |                                        --^^^^^^--
    |                                        | |
    |                                        | cannot infer type for type parameter `T` declared on the trait `AsRef`
    |                                        this method call resolves to `&T`
    |
    = note: cannot satisfy `std::string::String: AsRef<_>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0283`.
error: could not compile `serde_dhall`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```