### PR TITLE
make formats configurable

### DIFF
--- a/config-derive/Cargo.toml
+++ b/config-derive/Cargo.toml
@@ -1,24 +1,33 @@
 [package]
-name = "config-derive"
-version = "0.2.0"
-authors = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
-edition = "2018"
-license = "MIT"
-keywords = ["config", "configuration", "env", "environment", "settings"]
-categories = ["config"]
-readme = "README.md"
-homepage = "https://github.com/bnjjj/twelf"
-repository = "https://github.com/bnjjj/twelf"
-description = "Proc macro used by Twelf crate"
+    authors     = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
+    categories  = ["config"]
+    description = "Proc macro used by Twelf crate"
+    edition     = "2018"
+    homepage    = "https://github.com/bnjjj/twelf"
+    keywords    = ["config", "configuration", "env", "environment", "settings"]
+    license     = "MIT"
+    name        = "config-derive"
+    readme      = "README.md"
+    repository  = "https://github.com/bnjjj/twelf"
+    version     = "0.2.0"
 
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+    # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-proc-macro = true
+    proc-macro = true
 
 [dependencies]
-heck = "0.4.0"
-proc-macro2 = "1.0.36"
-quote = "1.0"
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+    heck        = "0.4.0"
+    proc-macro2 = "1.0.36"
+    quote       = "1.0"
+    syn         = { version = "1.0", features = ["full", "extra-traits"] }
+
+[features]
+    clap  = []
+    dhall = []
+    env   = []
+    ini   = []
+    json  = []
+    toml  = []
+    yaml  = []

--- a/config-derive/src/lib.rs
+++ b/config-derive/src/lib.rs
@@ -151,6 +151,7 @@ pub fn config(_attrs: TokenStream, item: TokenStream) -> TokenStream {
                 #opt_struct
 
                 let res = match priority {
+                    #[cfg(feature = "env")]
                     ::twelf::Layer::Env(prefix) => match prefix {
                         Some(prefix) => {
                             let tmp_cfg: #opt_struct_name #struct_gen = ::twelf::reexports::envy::prefixed(prefix).from_env()?;
@@ -161,14 +162,20 @@ pub fn config(_attrs: TokenStream, item: TokenStream) -> TokenStream {
                             ::twelf::reexports::serde_json::to_value(tmp_cfg)
                         },
                     }?,
+                    #[cfg(feature = "json")]
                     ::twelf::Layer::Json(filepath) => ::twelf::reexports::serde_json::from_reader(std::fs::File::open(filepath)?)?,
+                    #[cfg(feature = "toml")]
                     ::twelf::Layer::Toml(filepath) => ::twelf::reexports::toml::from_str(&std::fs::read_to_string(filepath)?)?,
+                    #[cfg(feature = "yaml")]
                     ::twelf::Layer::Yaml(filepath) => ::twelf::reexports::serde_yaml::from_str(&std::fs::read_to_string(filepath)?)?,
+                    #[cfg(feature = "dhall")]
                     ::twelf::Layer::Dhall(filepath) => ::twelf::reexports::serde_dhall::from_str(&std::fs::read_to_string(filepath)?).parse()?,
+                    #[cfg(feature = "ini")]
                     ::twelf::Layer::Ini(filepath) => {
                        let tmp_cfg: #opt_struct_name #struct_gen = ::twelf::reexports::serde_ini::from_str(&std::fs::read_to_string(filepath)?)?;
                        ::twelf::reexports::serde_json::to_value(tmp_cfg)?
                     },
+                    #[cfg(feature = "clap")]
                     ::twelf::Layer::Clap(matches) => {
                         let mut map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 

--- a/config-derive/src/lib.rs
+++ b/config-derive/src/lib.rs
@@ -192,6 +192,7 @@ pub fn config(_attrs: TokenStream, item: TokenStream) -> TokenStream {
                         let tmp_cfg: #opt_struct_name #struct_gen = ::twelf::reexports::envy::from_iter(map.into_iter())?;
                         ::twelf::reexports::serde_json::to_value(tmp_cfg)?
                     },
+                    _ => unimplemented!()
                 };
 
                 Ok(res)

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -19,7 +19,7 @@
     serde         = { version = "1", features = ["derive"] }
     serde_dhall   = { version = "0.11", optional = true }
     serde_ini     = { version = "0.2.0", optional = true }
-    serde_json    = { version = "1", optional = true }
+    serde_json    = "1"
     serde_yaml    = { version = "0.8.23", optional = true }
     thiserror     = "1"
     toml_rs       = { version = "0.5.8", package = "toml", optional = true }

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -1,25 +1,35 @@
 [package]
-name = "twelf"
-version = "0.2.0"
-authors = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
-edition = "2018"
-license = "MIT"
-keywords = ["config", "configuration", "env", "environment", "settings"]
-categories = ["config"]
-readme = "../README.md"
-homepage = "https://github.com/bnjjj/twelf"
-repository = "https://github.com/bnjjj/twelf"
-description = "Twelf is a configuration solution for Rust including 12-Factor support. It is designed with layers in order to configure different sources and formats to build your configuration. The main goal is to be very simple using a proc macro."
+    authors     = ["Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>"]
+    categories  = ["config"]
+    description = "Twelf is a configuration solution for Rust including 12-Factor support. It is designed with layers in order to configure different sources and formats to build your configuration. The main goal is to be very simple using a proc macro."
+    edition     = "2018"
+    homepage    = "https://github.com/bnjjj/twelf"
+    keywords    = ["config", "configuration", "env", "environment", "settings"]
+    license     = "MIT"
+    name        = "twelf"
+    readme      = "../README.md"
+    repository  = "https://github.com/bnjjj/twelf"
+    version     = "0.2.0"
 
 [dependencies]
-clap_rs = { version = "3.0", package = "clap" }
-config-derive = { path = "../config-derive", version = "0.2" }
-envy = { version = "0.4.1", git = "https://github.com/bnjjj/envy", branch = "master" }
-log = "0.4.14"
-serde = { version = "1", features = ["derive"] }
-serde_dhall = "0.11"
-serde_ini = "0.2.0"
-serde_json = "1"
-serde_yaml = "0.8.23"
-thiserror = "1"
-toml_rs = { version =  "0.5.8", package = "toml" }
+    clap_rs       = { version = "3.0", package = "clap", optional = true }
+    config-derive = { path = "../config-derive", version = "0.2" }
+    envy          = { version = "0.4.1", git = "https://github.com/bnjjj/envy", branch = "master", optional = true }
+    log           = "0.4.14"
+    serde         = { version = "1", features = ["derive"] }
+    serde_dhall   = { version = "0.11", optional = true }
+    serde_ini     = { version = "0.2.0", optional = true }
+    serde_json    = { version = "1", optional = true }
+    serde_yaml    = { version = "0.8.23", optional = true }
+    thiserror     = "1"
+    toml_rs       = { version = "0.5.8", package = "toml", optional = true }
+
+[features]
+    clap    = ["clap_rs", "config-derive/clap"]
+    default = ["envy", "dhall", "clap", "ini", "json", "yaml", "toml"]
+    dhall   = ["serde_dhall", "config-derive/dhall"]
+    env     = ["envy", "config-derive/env"]
+    ini     = ["serde_ini", "config-derive/ini"]
+    json    = ["serde_json", "config-derive/json"]
+    toml    = ["toml_rs", "config-derive/toml"]
+    yaml    = ["serde_yaml", "config-derive/yaml"]

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -26,7 +26,7 @@
 
 [features]
     clap    = ["clap_rs", "config-derive/clap"]
-    default = ["envy", "dhall", "clap", "ini", "json", "yaml", "toml"]
+    default = ["env", "dhall", "clap", "ini", "json", "yaml", "toml"]
     dhall   = ["serde_dhall", "config-derive/dhall"]
     env     = ["envy", "config-derive/env"]
     ini     = ["serde_ini", "config-derive/ini"]

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -30,6 +30,6 @@
     dhall   = ["serde_dhall", "config-derive/dhall"]
     env     = ["envy", "config-derive/env"]
     ini     = ["serde_ini", "config-derive/ini"]
-    json    = ["serde_json", "config-derive/json"]
+    json    = ["config-derive/json"]
     toml    = ["toml_rs", "config-derive/toml"]
     yaml    = ["serde_yaml", "config-derive/yaml"]

--- a/twelf/src/error.rs
+++ b/twelf/src/error.rs
@@ -8,7 +8,6 @@ pub enum Error {
     #[cfg(feature = "env")]
     #[error("envy serde error")]
     Envy(#[from] envy::Error),
-    #[cfg(feature = "json")]
     #[error("json serde error")]
     Json(#[from] serde_json::Error),
     #[cfg(feature = "toml")]

--- a/twelf/src/error.rs
+++ b/twelf/src/error.rs
@@ -5,16 +5,22 @@ use thiserror::Error as ErrorTrait;
 pub enum Error {
     #[error("io error")]
     Io(#[from] std::io::Error),
+    #[cfg(feature = "env")]
     #[error("envy serde error")]
     Envy(#[from] envy::Error),
+    #[cfg(feature = "json")]
     #[error("json serde error")]
     Json(#[from] serde_json::Error),
+    #[cfg(feature = "toml")]
     #[error("toml serde error")]
     Toml(#[from] toml_rs::de::Error),
+    #[cfg(feature = "yaml")]
     #[error("yaml serde error")]
     Yaml(#[from] serde_yaml::Error),
+    #[cfg(feature = "ini")]
     #[error("ini serde error")]
     Ini(#[from] serde_ini::de::Error),
+    #[cfg(feature = "dhall")]
     #[error("dhall serde error")]
     Dhall(#[from] serde_dhall::Error),
     #[error("invalid format")]

--- a/twelf/src/lib.rs
+++ b/twelf/src/lib.rs
@@ -58,16 +58,22 @@ use std::path::PathBuf;
 
 #[doc(hidden)]
 pub mod reexports {
-    pub use envy;
     pub use log;
-
     pub use serde;
-    pub use serde_json;
 
+    #[cfg(feature = "clap")]
     pub use clap_rs as clap;
+    #[cfg(feature = "env")]
+    pub use envy;
+    #[cfg(feature = "dhall")]
     pub use serde_dhall;
+    #[cfg(feature = "ini")]
     pub use serde_ini;
+    #[cfg(feature = "json")]
+    pub use serde_json;
+    #[cfg(feature = "yaml")]
     pub use serde_yaml;
+    #[cfg(feature = "toml")]
     pub use toml_rs as toml;
 }
 
@@ -78,17 +84,24 @@ pub use error::Error;
 #[derive(Debug, Clone)]
 pub enum Layer {
     /// Env layer taking an optional prefix for environment variables
+    #[cfg(feature = "env")]
     Env(Option<String>),
     /// Json layer taking file path to the json file
+    #[cfg(feature = "json")]
     Json(PathBuf),
     /// Yaml layer taking file path to the yaml file
+    #[cfg(feature = "yaml")]
     Yaml(PathBuf),
     /// Toml layer taking file path to the toml file
+    #[cfg(feature = "toml")]
     Toml(PathBuf),
     /// Ini layer taking file path to the ini file
+    #[cfg(feature = "ini")]
     Ini(PathBuf),
     /// Dhall layer taking file path to the dhall file
+    #[cfg(feature = "dhall")]
     Dhall(PathBuf),
     /// Clap layer taking arguments matches from a clap application
+    #[cfg(feature = "clap")]
     Clap(clap_rs::ArgMatches),
 }

--- a/twelf/src/lib.rs
+++ b/twelf/src/lib.rs
@@ -60,6 +60,7 @@ use std::path::PathBuf;
 pub mod reexports {
     pub use log;
     pub use serde;
+    pub use serde_json;
 
     #[cfg(feature = "clap")]
     pub use clap_rs as clap;
@@ -69,8 +70,6 @@ pub mod reexports {
     pub use serde_dhall;
     #[cfg(feature = "ini")]
     pub use serde_ini;
-    #[cfg(feature = "json")]
-    pub use serde_json;
     #[cfg(feature = "yaml")]
     pub use serde_yaml;
     #[cfg(feature = "toml")]


### PR DESCRIPTION
due to project reasons i cant use AGPL licenses.
`serde_dhall` depends indirectly on `abnf` which is AGPL licensed.

the introduced features make it confgurable which loaders will be enabled