### PR TITLE
Fix build error when env is not in features flags

### DIFF
--- a/config-derive/src/lib.rs
+++ b/config-derive/src/lib.rs
@@ -224,15 +224,15 @@ fn build_clap_branch(
     (clap_branch, clap_method)
 }
 
-fn build_env_branch(opt_struct_name: &Ident, struct_gen: &Generics) -> proc_macro2::TokenStream {
+fn build_env_branch(_opt_struct_name: &Ident, _struct_gen: &Generics) -> proc_macro2::TokenStream {
     #[cfg(feature = "env")]
     let env_branch = quote! { ::twelf::Layer::Env(prefix) => match prefix {
         Some(prefix) => {
-            let tmp_cfg: #opt_struct_name #struct_gen = ::twelf::reexports::envy::prefixed(prefix).from_env()?;
+            let tmp_cfg: #_opt_struct_name #_struct_gen = ::twelf::reexports::envy::prefixed(prefix).from_env()?;
             ::twelf::reexports::serde_json::to_value(tmp_cfg)
         },
         None => {
-            let tmp_cfg: #opt_struct_name #struct_gen = ::twelf::reexports::envy::from_env()?;
+            let tmp_cfg: #_opt_struct_name #_struct_gen = ::twelf::reexports::envy::from_env()?;
             ::twelf::reexports::serde_json::to_value(tmp_cfg)
         },
     }?,};
@@ -273,10 +273,10 @@ fn build_dhall_branch() -> proc_macro2::TokenStream {
     dhall_branch
 }
 
-fn build_ini_branch(opt_struct_name: &Ident, struct_gen: &Generics) -> proc_macro2::TokenStream {
+fn build_ini_branch(_opt_struct_name: &Ident, _struct_gen: &Generics) -> proc_macro2::TokenStream {
     #[cfg(feature = "ini")]
     let ini_branch = quote! { ::twelf::Layer::Ini(filepath) => {
-       let tmp_cfg: #opt_struct_name #struct_gen = ::twelf::reexports::serde_ini::from_str(&std::fs::read_to_string(filepath)?)?;
+       let tmp_cfg: #_opt_struct_name #_struct_gen = ::twelf::reexports::serde_ini::from_str(&std::fs::read_to_string(filepath)?)?;
        ::twelf::reexports::serde_json::to_value(tmp_cfg)?
     }, };
     #[cfg(not(feature = "ini"))]

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -25,7 +25,7 @@
     toml_rs       = { version = "0.5.8", package = "toml", optional = true }
 
 [features]
-    clap    = ["clap_rs", "config-derive/clap"]
+    clap    = ["clap_rs", "config-derive/clap", "envy"]
     default = ["env", "dhall", "clap", "ini", "json", "yaml", "toml"]
     dhall   = ["serde_dhall", "config-derive/dhall"]
     env     = ["envy", "config-derive/env"]

--- a/twelf/src/error.rs
+++ b/twelf/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error as ErrorTrait;
 pub enum Error {
     #[error("io error")]
     Io(#[from] std::io::Error),
-    #[cfg(feature = "env")]
+    #[cfg(any(feature = "env", feature = "clap"))]
     #[error("envy serde error")]
     Envy(#[from] envy::Error),
     #[error("json serde error")]

--- a/twelf/src/lib.rs
+++ b/twelf/src/lib.rs
@@ -12,7 +12,7 @@ pub mod reexports {
 
     #[cfg(feature = "clap")]
     pub use clap_rs as clap;
-    #[cfg(feature = "env")]
+    #[cfg(any(feature = "env", feature = "clap"))]
     pub use envy;
     #[cfg(feature = "dhall")]
     pub use serde_dhall;


### PR DESCRIPTION
add `envy` dependency in `clap` features

fixes #16 