### PR TITLE
Reduce default features and fix warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --all-features --verbose

--- a/README.md
+++ b/README.md
@@ -71,7 +71,17 @@ Twelf supports crate features, if you only want support for `json`, `env` and `t
 twelf = { version = "0.4", default-features = false, features = ["json", "toml", "env"] }
 ```
 
-Default features are `["env", "dhall", "clap", "ini", "json", "yaml", "toml"]`
+Default features are `["env", "clap"]`
+
+# Contributing
+
+Feel free to contribute to the `twelf` project.
+
+Enable all features when testing changes to the crate:
+
+```console
+cargo test --all-features
+```
 
 # Alternatives
 

--- a/config-derive/README.md
+++ b/config-derive/README.md
@@ -70,7 +70,17 @@ Twelf supports crate features, if you only want support for `json`, `env` and `t
 twelf = { version = "0.3", default-features = false, features = ["json", "toml", "env"] }
 ```
 
-Default features are `["env", "dhall", "clap", "ini", "json", "yaml", "toml"]`
+Default features are `["env", "clap"]`
+
+# Contributing
+
+Feel free to contribute to the `twelf` project.
+
+Enable all features when testing changes to the crate:
+
+```console
+cargo test --all-features
+```
 
 # Alternatives
 

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -26,7 +26,8 @@
 
 [features]
     clap    = ["clap_rs", "config-derive/clap", "envy"]
-    default = ["env", "dhall", "clap", "ini", "json", "yaml", "toml"]
+    default = ["env", "clap"]
+    # default = ["env", "dhall", "clap", "ini", "json", "yaml", "toml"]
     dhall   = ["serde_dhall", "config-derive/dhall"]
     env     = ["envy", "config-derive/env"]
     ini     = ["serde_ini", "config-derive/ini"]

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -27,7 +27,6 @@
 [features]
     clap    = ["clap_rs", "config-derive/clap", "envy"]
     default = ["env", "clap"]
-    # default = ["env", "dhall", "clap", "ini", "json", "yaml", "toml"]
     dhall   = ["serde_dhall", "config-derive/dhall"]
     env     = ["envy", "config-derive/env"]
     ini     = ["serde_ini", "config-derive/ini"]

--- a/twelf/README.md
+++ b/twelf/README.md
@@ -70,7 +70,17 @@ Twelf supports crate features, if you only want support for `json`, `env` and `t
 twelf = { version = "0.3", default-features = false, features = ["json", "toml", "env"] }
 ```
 
-Default features are `["env", "dhall", "clap", "ini", "json", "yaml", "toml"]`
+Default features are `["env", "clap"]`
+
+# Contributing
+
+Feel free to contribute to the `twelf` project.
+
+Enable all features when testing changes to the crate:
+
+```console
+cargo test --all-features
+```
 
 # Alternatives
 

--- a/twelf/src/lib.rs
+++ b/twelf/src/lib.rs
@@ -2,6 +2,13 @@
 
 mod error;
 
+#[cfg(any(
+    feature = "json",
+    feature = "yaml",
+    feature = "toml",
+    feature = "ini",
+    feature = "dhall"
+))]
 use std::path::PathBuf;
 
 #[doc(hidden)]


### PR DESCRIPTION
I propose to exclude from default features:
- `dhall` feature (see #17)
- other file format related features

fixes #17 