### PR TITLE
Make clap defaults not override previous layers

### DIFF
--- a/config-derive/src/lib.rs
+++ b/config-derive/src/lib.rs
@@ -155,7 +155,7 @@ pub fn config(_attrs: TokenStream, item: TokenStream) -> TokenStream {
                         .as_object()
                         .ok_or_else(|| ::twelf::Error::InvalidFormat)?
                         .to_owned()
-                        .into_iter().filter(|(k, v)| ((defaulted.contains_key(k) && !defaulted[k]) || !res.contains_key(k)) && !v.is_null())
+                        .into_iter().filter(|(k, v)| (!defaulted.contains_key(k) || !defaulted[k] || !res.contains_key(k)) && !v.is_null())
                         .collect(); // must collect, as filter uses res
 
                     res.extend(extension);


### PR DESCRIPTION
Hey, I've noticed that the clap layer overrides previous layers if a clap `default_value` is given.

For example on current master try:
```
APP_THREADS=4 cargo run --example clap_derive -- --db-host localhost --verbose
```

It will print:
```
config - Config { db_host: "localhost", threads: 55, verbose: true }
```

But I'd expect it to print :
```
config - Config { db_host: "localhost", threads: 4, verbose: true }
```

This PR solves this by tracking for each value if the provided value was a default value, and does not override existing values then.
I've implemented it in a way, where other layers also could easily have default values, not just clap, but I guess it doesn't make sense for the other currently existing layers.

Note, that the first Layer providing a default value will set the value, if later layers also set a default value for the same key they will be ignored in this implementation.