### PR TITLE
Proposale: introduce default trait

### DIFF
--- a/config-derive/Cargo.toml
+++ b/config-derive/Cargo.toml
@@ -33,3 +33,4 @@
     json  = []
     toml  = []
     yaml  = []
+    default_trait = []

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -13,7 +13,7 @@
 
 [dependencies]
     clap_rs       = { version = "4", package = "clap", optional = true, features = ["derive"] }
-    config-derive = { path = "../config-derive", version = "0.9" }
+    config-derive  = { path = "../config-derive", version = "0.9" }
     envy          = { version = "0.4.1", git = "https://github.com/bnjjj/envy", branch = "master", optional = true }
     log           = "0.4.14"
     serde         = { version = "1", features = ["derive"] }
@@ -33,3 +33,4 @@
     json    = ["config-derive/json"]
     toml    = ["toml_rs", "config-derive/toml"]
     yaml    = ["serde_yaml", "config-derive/yaml"]
+    default_trait = ["config-derive/default_trait"]

--- a/twelf/src/lib.rs
+++ b/twelf/src/lib.rs
@@ -58,4 +58,7 @@ pub enum Layer {
     /// Clap layer taking arguments matches from a clap application
     #[cfg(feature = "clap")]
     Clap(clap_rs::ArgMatches),
+    /// Default layer, using std::default::Default trait
+    #[cfg(feature = "default_trait")]
+    DefaultTrait,
 }

--- a/twelf/tests/default.rs
+++ b/twelf/tests/default.rs
@@ -1,0 +1,33 @@
+use config_derive::config;
+use twelf::Layer;
+
+#[test]
+fn default_simple_types() {
+    #[config]
+    #[derive(Debug)]
+    struct TestCfg {
+        test: String,
+        another: usize,
+    }
+
+    impl Default for TestCfg {
+        fn default() -> Self {
+            Self {
+                test: "from default".to_owned(),
+                another: 25,
+            }
+        }
+    }
+
+    std::env::set_var("ANOTHER", "5");
+
+    let prio = vec![Layer::DefaultTrait, Layer::Env(None)];
+    let config = TestCfg::with_layers(&prio).unwrap();
+    assert_eq!(config.test, String::from("from default"));
+    assert_eq!(config.another, 5usize);
+
+    let prio = vec![Layer::Env(None), Layer::DefaultTrait];
+    let config = TestCfg::with_layers(&prio).unwrap();
+    assert_eq!(config.test, String::from("from default"));
+    assert_eq!(config.another, 25usize);
+}


### PR DESCRIPTION
Hello 👋 

I recently fork `twelf` to use it `std::default::Default`. My needs were:

- enforce all configs to have default values
- use default config, if it's not set from environment

I made a simple patch (under feature `default_trait`) that may be useful for other 🤷‍♂️ so I post it here.

It can be used as follows:

```rust
use twelf::{config, Layer};

#[config]
struct Conf {
    test: String,
    another: usize,
}

impl std::default::Default for Configuration {
    fn default() -> Self { 
        Self {
            test: "default test".to_owned(),
            another: 12,
        }
    }
}

// Init configuration with layers, each layers override only existing fields
let config = Conf::with_layers(&[
    Layer::DefaultTrait,
    Layer::Env(Some("PREFIX_".to_string()))
]).unwrap();
```
