### PR TITLE
Adding CustomFn layer

### DIFF
--- a/config-derive/Cargo.toml
+++ b/config-derive/Cargo.toml
@@ -34,3 +34,4 @@
     toml  = []
     yaml  = []
     default_trait = []
+    custom_fn = []

--- a/config-derive/src/lib.rs
+++ b/config-derive/src/lib.rs
@@ -119,6 +119,7 @@ pub fn config(_attrs: TokenStream, item: TokenStream) -> TokenStream {
     let yaml_branch = build_yaml_branch();
     let dhall_branch = build_dhall_branch();
     let default_trait_branch = build_default_trait_branch();
+    let custom_fn_branch = build_custom_fn_branch();
 
     #[cfg(not(feature = "ini"))]
     let ini_branch = quote! {};
@@ -141,9 +142,9 @@ pub fn config(_attrs: TokenStream, item: TokenStream) -> TokenStream {
         docs,
     );
 
-    #[cfg(not(feature = "default_trait"))]
+    #[cfg(all(not(feature = "default_trait"), not(feature = "custom_fn")))]
     let derive_serialize = quote! {};
-    #[cfg(feature = "default_trait")]
+    #[cfg(any(feature = "default_trait", feature = "custom_fn"))]
     let derive_serialize = quote! { #[derive(::twelf::reexports::serde::Serialize)] };
 
     let code = quote! {
@@ -192,6 +193,7 @@ pub fn config(_attrs: TokenStream, item: TokenStream) -> TokenStream {
                     #ini_branch
                     #clap_branch
                     #default_trait_branch
+                    #custom_fn_branch
                     other => unimplemented!("{:?}", other)
                 };
 
@@ -326,4 +328,12 @@ fn build_default_trait_branch() -> proc_macro2::TokenStream {
     #[cfg(not(feature = "default_trait"))]
     let default_trait_branch = quote! {};
     default_trait_branch
+}
+
+fn build_custom_fn_branch() -> proc_macro2::TokenStream {
+    #[cfg(feature = "custom_fn")]
+    let custom_branch = quote! { ::twelf::Layer::CustomFn(custom_fn) => (custom_fn.0(),None), };
+    #[cfg(not(feature = "custom_fn"))]
+    let custom_branch = quote! {};
+    custom_branch
 }

--- a/twelf/Cargo.toml
+++ b/twelf/Cargo.toml
@@ -23,6 +23,7 @@
     serde_yaml    = { version = "0.8.23", optional = true }
     thiserror     = "1"
     toml_rs       = { version = "0.5.8", package = "toml", optional = true }
+    dyn-clone     = { version = "1.0.0", optional = true }
 
 [features]
     clap    = ["clap_rs", "config-derive/clap", "envy"]
@@ -34,3 +35,4 @@
     toml    = ["toml_rs", "config-derive/toml"]
     yaml    = ["serde_yaml", "config-derive/yaml"]
     default_trait = ["config-derive/default_trait"]
+    custom_fn = ["dyn-clone", "config-derive/custom_fn"]

--- a/twelf/README.md
+++ b/twelf/README.md
@@ -23,6 +23,7 @@ For now it supports :
 use twelf::{config, Layer};
 
 #[config]
+#[derive(Default)]
 struct Conf {
     test: String,
     another: usize,

--- a/twelf/examples/advanced_struct.rs
+++ b/twelf/examples/advanced_struct.rs
@@ -6,7 +6,7 @@ use twelf::reexports::serde::{Deserialize, Serialize};
 use twelf::{config, Layer};
 
 #[config]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Config {
     list: Vec<String>,
     labels: HashMap<String, String>,
@@ -14,7 +14,7 @@ struct Config {
     nested: Nested,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 struct Nested {
     inner: String,
 }

--- a/twelf/examples/clap.rs
+++ b/twelf/examples/clap.rs
@@ -4,7 +4,7 @@ use clap_rs as clap;
 use twelf::{config, Layer};
 
 #[config]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Config {
     /// Documentation inside clap, to specifiy db_host
     db_host: String,

--- a/twelf/examples/clap_derive.rs
+++ b/twelf/examples/clap_derive.rs
@@ -5,7 +5,7 @@ use clap_rs as clap;
 use twelf::{config, Layer};
 
 #[config]
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[clap(author, version, about, long_about = None)]
 struct Config {
     #[clap(long, help = "Documentation inside clap, to specifiy db_host")]

--- a/twelf/examples/default_env.rs
+++ b/twelf/examples/default_env.rs
@@ -3,7 +3,7 @@
 use twelf::{config, Layer};
 
 #[config]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Config {
     db_host: String,
     threads: usize,

--- a/twelf/examples/simple_env_json.rs
+++ b/twelf/examples/simple_env_json.rs
@@ -3,7 +3,7 @@
 use twelf::{config, Layer};
 
 #[config]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Config {
     db_host: String,
     threads: usize,

--- a/twelf/src/lib.rs
+++ b/twelf/src/lib.rs
@@ -61,4 +61,36 @@ pub enum Layer {
     /// Default layer, using std::default::Default trait
     #[cfg(feature = "default_trait")]
     DefaultTrait,
+    /// Custom layer taking file path to the json file
+    #[cfg(feature = "custom_fn")]
+    CustomFn(custom_fn::CustomFn),
+}
+
+#[cfg(feature = "custom_fn")]
+pub mod custom_fn {
+    use dyn_clone::{DynClone, clone_box};
+
+    pub struct CustomFn(pub Box<dyn CustomFnTrait>);
+
+    impl<T> From<T> for CustomFn where T: Fn() -> crate::reexports::serde_json::Value + Clone + 'static {
+        fn from(func: T) -> Self {
+            CustomFn(Box::new(func) as Box<dyn CustomFnTrait>)
+        }
+    }
+
+    pub trait CustomFnTrait: Fn() -> crate::reexports::serde_json::Value + DynClone {}
+
+    impl<T> CustomFnTrait for T where T: Clone + Fn() -> crate::reexports::serde_json::Value {}
+
+    impl Clone for CustomFn {
+        fn clone(&self) -> Self {
+            CustomFn(clone_box(&*self.0) as Box<dyn CustomFnTrait>)
+        }
+    }
+
+    impl core::fmt::Debug for CustomFn {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "CustomFn")
+        } 
+    }
 }

--- a/twelf/tests/clap.rs
+++ b/twelf/tests/clap.rs
@@ -10,7 +10,7 @@ const JSON_TEST_FILE: &str = "./tests/fixtures/test.json";
 #[test]
 fn clap_with_array_and_hashmap() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         /// My custom documentation on elements-snake in clap
         elements_snake: HashMap<String, String>,
@@ -50,7 +50,7 @@ fn clap_with_array_and_hashmap() {
 #[test]
 fn clap_derive_array() {
     #[config]
-    #[derive(Parser,Debug)]
+    #[derive(Parser,Debug, Default)]
     #[clap(author, version, about, long_about = None)]
     struct Conf {
         #[clap(long, default_value_t = 55)]

--- a/twelf/tests/custom_fn.rs
+++ b/twelf/tests/custom_fn.rs
@@ -1,0 +1,31 @@
+
+use config_derive::config;
+use twelf::Layer;
+
+use serde_json::value::to_value;
+
+#[test]
+fn simple_custom_fn() {
+    #[config]
+    #[derive(Debug, Default)]
+    struct TestCfg {
+        test: String,
+        another: usize,
+    }
+
+    std::env::set_var("ANOTHER", "5");
+
+    let func = || {
+        to_value(TestCfg{test: "from func".to_string(), another: 25}).unwrap()
+    };
+
+    let prio = vec![Layer::CustomFn(func.into()), Layer::Env(None)];
+    let config = TestCfg::with_layers(&prio).unwrap();
+    assert_eq!(config.test, String::from("from func"));
+    assert_eq!(config.another, 5usize);
+
+    let prio = vec![Layer::Env(None), Layer::CustomFn(func.into())];
+    let config = TestCfg::with_layers(&prio).unwrap();
+    assert_eq!(config.test, String::from("from func"));
+    assert_eq!(config.another, 25usize);
+}

--- a/twelf/tests/dhall.rs
+++ b/twelf/tests/dhall.rs
@@ -12,7 +12,7 @@ const DHALL_TEST_FILE: &str = "./tests/fixtures/test.dhall";
 #[test]
 fn dhall_simple_types() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -32,7 +32,7 @@ fn dhall_simple_types() {
 #[test]
 fn dhall_simple_with_prefix() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -57,7 +57,7 @@ fn dhall_simple_with_prefix() {
 #[test]
 fn dhall_simple_with_option() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: Option<HashMap<String, String>>,
         array_def: Option<Vec<String>>,
@@ -80,7 +80,7 @@ fn dhall_simple_with_option() {
 #[test]
 fn dhall_with_array_and_hashmap_string() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -113,7 +113,7 @@ fn dhall_with_array_and_hashmap_string() {
 #[test]
 fn dhall_with_array_and_hashmap_with_default() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]

--- a/twelf/tests/ini.rs
+++ b/twelf/tests/ini.rs
@@ -12,7 +12,7 @@ const INI_TEST_FILE: &str = "./tests/fixtures/test.ini";
 #[test]
 fn ini_simple_types() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -32,7 +32,7 @@ fn ini_simple_types() {
 #[test]
 fn ini_simple_with_prefix() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         /// Coucou
         elements_def: HashMap<String, String>,
@@ -58,7 +58,7 @@ fn ini_simple_with_prefix() {
 #[test]
 fn ini_simple_with_option() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: Option<HashMap<String, String>>,
         array_def: Option<Vec<String>>,
@@ -81,7 +81,7 @@ fn ini_simple_with_option() {
 #[test]
 fn ini_with_array_and_hashmap_string() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -114,7 +114,7 @@ fn ini_with_array_and_hashmap_string() {
 #[test]
 fn ini_with_array_and_hashmap_with_default() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]

--- a/twelf/tests/json.rs
+++ b/twelf/tests/json.rs
@@ -12,7 +12,7 @@ const JSON_TEST_FILE: &str = "./tests/fixtures/test.json";
 #[test]
 fn json_simple_types() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -32,7 +32,7 @@ fn json_simple_types() {
 #[test]
 fn json_simple_with_prefix() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -57,7 +57,7 @@ fn json_simple_with_prefix() {
 #[test]
 fn json_simple_with_option() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: Option<HashMap<String, String>>,
         array_def: Option<Vec<String>>,
@@ -80,7 +80,7 @@ fn json_simple_with_option() {
 #[test]
 fn json_with_array_and_hashmap_string() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -113,7 +113,7 @@ fn json_with_array_and_hashmap_string() {
 #[test]
 fn json_with_array_and_hashmap_with_default() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]

--- a/twelf/tests/mixed.rs
+++ b/twelf/tests/mixed.rs
@@ -18,7 +18,7 @@ const JSON_TEST_FILE: &str = "./tests/fixtures/test.json";
 #[test]
 fn missing_values() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -31,7 +31,7 @@ fn missing_values() {
 #[test]
 fn simple_only_env() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -46,13 +46,13 @@ fn simple_only_env() {
 
 #[test]
 fn nested_only_env() {
-    #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     struct Another {
         inner: String,
         // second: u8,
     }
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         #[serde(flatten)]
@@ -77,7 +77,7 @@ fn nested_only_env() {
 #[test]
 fn mixed_simple_types() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -105,7 +105,7 @@ fn mixed_simple_types() {
 #[test]
 fn mixed_simple_with_prefix() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -131,7 +131,7 @@ fn mixed_simple_with_prefix() {
 #[test]
 fn mixed_simple_with_option() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: Option<HashMap<String, String>>,
         array_def: Option<Vec<String>>,
@@ -155,7 +155,7 @@ fn mixed_simple_with_option() {
 #[test]
 fn mixed_with_array_and_hashmap_string() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -196,7 +196,7 @@ fn mixed_with_array_and_hashmap_string() {
 #[test]
 fn mixed_with_array_and_hashmap_with_default() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -222,7 +222,7 @@ fn mixed_with_array_and_hashmap_with_default() {
 #[test]
 fn mixed_clap_defaults() {
     #[config]
-    #[derive(Parser,Debug)]
+    #[derive(Parser, Debug, Default)]
     #[clap(author, version, about, long_about = None)]
     struct Conf {
         #[clap(long, default_value_t = 55)]

--- a/twelf/tests/toml.rs
+++ b/twelf/tests/toml.rs
@@ -12,7 +12,7 @@ const TOML_TEST_FILE: &str = "./tests/fixtures/test.toml";
 #[test]
 fn toml_simple_types() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -32,7 +32,7 @@ fn toml_simple_types() {
 #[test]
 fn toml_simple_with_prefix() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -57,7 +57,7 @@ fn toml_simple_with_prefix() {
 #[test]
 fn toml_simple_with_option() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: Option<HashMap<String, String>>,
         array_def: Option<Vec<String>>,
@@ -80,7 +80,7 @@ fn toml_simple_with_option() {
 #[test]
 fn toml_with_array_and_hashmap_string() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -113,7 +113,7 @@ fn toml_with_array_and_hashmap_string() {
 #[test]
 fn toml_with_array_and_hashmap_with_default() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]

--- a/twelf/tests/yaml.rs
+++ b/twelf/tests/yaml.rs
@@ -12,7 +12,7 @@ const YAML_TEST_FILE: &str = "./tests/fixtures/test.yaml";
 #[test]
 fn yaml_simple_types() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestCfg {
         test: String,
         another: usize,
@@ -32,7 +32,7 @@ fn yaml_simple_types() {
 #[test]
 fn yaml_simple_with_prefix() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -57,7 +57,7 @@ fn yaml_simple_with_prefix() {
 #[test]
 fn yaml_simple_with_option() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: Option<HashMap<String, String>>,
         array_def: Option<Vec<String>>,
@@ -80,7 +80,7 @@ fn yaml_simple_with_option() {
 #[test]
 fn yaml_with_array_and_hashmap_string() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements: HashMap<String, String>,
         #[serde(default = "default_array")]
@@ -113,7 +113,7 @@ fn yaml_with_array_and_hashmap_string() {
 #[test]
 fn yaml_with_array_and_hashmap_with_default() {
     #[config]
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Conf {
         elements_def: HashMap<String, String>,
         #[serde(default = "default_array")]


### PR DESCRIPTION
Adding CustomFn layer, where any Fn type, (function or immutable closure) can provide config values.

This is useful to support additional data sources, for example to get values from a database or from an unsupported file format, e.g. hjson (https://crates.io/crates/deser-hjson)

Thank you.