### PR TITLE
Strip out comments in config files before passing to `shellexpand`

### DIFF
--- a/config-derive/src/lib.rs
+++ b/config-derive/src/lib.rs
@@ -298,6 +298,9 @@ fn build_toml_branch() -> proc_macro2::TokenStream {
     #[cfg(feature = "toml")]
     let toml_branch = quote! { ::twelf::Layer::Toml(filepath) => {
         let file_content = std::fs::read_to_string(filepath)?;
+        // Strip out comments (lines starting with #)
+        let file_content = file_content.lines().filter(|line| !line.trim().starts_with("#")).collect::<Vec<_>>().join("\n");
+
         let content = ::twelf::reexports::shellexpand::env(&file_content)?;
         (::twelf::reexports::toml::from_str(&content)?,None)
     }, };
@@ -310,6 +313,8 @@ fn build_yaml_branch() -> proc_macro2::TokenStream {
     #[cfg(feature = "yaml")]
     let yaml_branch = quote! { ::twelf::Layer::Yaml(filepath) => {
         let file_content = std::fs::read_to_string(filepath)?;
+        // Strip out comments (lines starting with #)
+        let file_content = file_content.lines().filter(|line| !line.trim().starts_with("#")).collect::<Vec<_>>().join("\n");
         let content = ::twelf::reexports::shellexpand::env(&file_content)?;
         (::twelf::reexports::serde_yaml::from_str(&content)?,None)
     }, };
@@ -322,6 +327,9 @@ fn build_dhall_branch() -> proc_macro2::TokenStream {
     #[cfg(feature = "dhall")]
     let dhall_branch = quote! { ::twelf::Layer::Dhall(filepath) => {
         let file_content = std::fs::read_to_string(filepath)?;
+        // Strip out comments (lines starting with --)
+        let file_content = file_content.lines().filter(|line| !line.trim().starts_with("--")).collect::<Vec<_>>().join("\n");
+
         let content = ::twelf::reexports::shellexpand::env(&file_content)?;
         (::twelf::reexports::serde_dhall::from_str(&content).parse()?,None)
     }, };
@@ -334,6 +342,8 @@ fn build_dhall_branch() -> proc_macro2::TokenStream {
 fn build_ini_branch(opt_struct_name: &Ident, struct_gen: &Generics) -> proc_macro2::TokenStream {
     quote! { ::twelf::Layer::Ini(filepath) => {
         let file_content = std::fs::read_to_string(filepath)?;
+        // Strip out comments (lines starting with ;)
+        let file_content = file_content.lines().filter(|line| !line.trim().starts_with(";")).collect::<Vec<_>>().join("\n");
         let content = ::twelf::reexports::shellexpand::env(&file_content)?;
        let tmp_cfg: #opt_struct_name #struct_gen = ::twelf::reexports::serde_ini::from_str(&content)?;
        (::twelf::reexports::serde_json::to_value(tmp_cfg)?,None)

--- a/twelf/tests/fixtures/test.dhall
+++ b/twelf/tests/fixtures/test.dhall
@@ -1,6 +1,7 @@
 {
     test = "from file",
     another = 25,
+    -- Single-line comment ${FOO}
     elements = {
         key = "value",
         key2 = "value2"

--- a/twelf/tests/fixtures/test.ini
+++ b/twelf/tests/fixtures/test.ini
@@ -1,5 +1,6 @@
 test=from file
 another=25
+; This is a comment ${FOO}
 
 [elements]
 key=value

--- a/twelf/tests/fixtures/test.toml
+++ b/twelf/tests/fixtures/test.toml
@@ -1,3 +1,4 @@
+# private_key = "${FOO}"
 test = 'from file'
 another = 25
 

--- a/twelf/tests/fixtures/test.yaml
+++ b/twelf/tests/fixtures/test.yaml
@@ -1,6 +1,7 @@
 ---
 test: from file
 another: 25
+# This is a comment ${FOO}
 elements:
   key: value
   key2: value2


### PR DESCRIPTION
Applied the fix to all config files with comment support.

The one downside is, that I had to repeat the same code in each function. That is due to `#[proc_macro]` crate rules: according to Rust's restrictions, these crates can only export items that are procedural macros themselves.

Fixes #37